### PR TITLE
89 Add support for multiple metrics

### DIFF
--- a/src/configs/main.yaml
+++ b/src/configs/main.yaml
@@ -4,13 +4,16 @@ defaults:
   - metric: ppc
   - _self_
 
+metrics_sweep: "c2st, ppc"
+
 random_seed: 86
 postprocess: true
 
 hydra:
   mode: MULTIRUN
   sweeper:
-    params:
+    params: 
+      metric: ${metrics_sweep} 
       inference.num_simulations: ${inference.num_simulations}
 
   callbacks:

--- a/src/utils/benchmark_run.py
+++ b/src/utils/benchmark_run.py
@@ -1,13 +1,12 @@
 import random
-import torch
 import pandas as pd
-from omegaconf import OmegaConf, ListConfig, DictConfig
+from omegaconf import OmegaConf, ListConfig
 from pathlib import Path
 
 from src.evaluation.evaluate_inference import evaluate_inference
 from src.inference.Run_Inference import run_inference
 from src.tasks.misspecified_tasks import LikelihoodMisspecifiedTask
-from src.utils.LinePlot import LinePlot
+
 
 
 # Task registry to hold all available task classes
@@ -63,16 +62,8 @@ def run_benchmark(config):
     # Determine which metrics to compute based on config
     metrics_raw = config.metric
 
-    # NOrmalize metrics_raw to a list
-    if isinstance(metrics_raw, (list, ListConfig)):
-        metrics_items = list(metrics_raw)
-    elif metrics_raw is None:
-        metrics_items = []
-    else:
-        metrics_items = [metrics_raw]
-
     metric_name = str(getattr(config.metric, "name", config.metric)).lower()
-    metrics = [metric_name]  # keep your existing for-loop over `metrics`
+    metrics = [metric_name] if metric_name else [] # Default to empty list if no metric specified
     print(f"metrics resolved: {metrics}")
 
 
@@ -110,6 +101,6 @@ def run_benchmark(config):
     else:
         # Save one .csv for each metric
         for metric_name, subdf in df.groupby("metric"):
-            csv_path = outdir/f"metrics_{metric_name}.csv"
+            csv_path = outdir/f"metrics_{metric_name.upper()}.csv"
             subdf.to_csv(csv_path, index=False)
-            print(f"Saved {metric_name} metrics ➜{csv_path}")
+            print(f"Saved {metric_name.upper()} metrics ➜{csv_path}")

--- a/src/utils/benchmark_run.py
+++ b/src/utils/benchmark_run.py
@@ -1,12 +1,13 @@
 import random
 import torch
-import os
 import pandas as pd
-from omegaconf import OmegaConf
+from omegaconf import OmegaConf, ListConfig, DictConfig
+from pathlib import Path
 
 from src.evaluation.evaluate_inference import evaluate_inference
 from src.inference.Run_Inference import run_inference
 from src.tasks.misspecified_tasks import LikelihoodMisspecifiedTask
+from src.utils.LinePlot import LinePlot
 
 
 # Task registry to hold all available task classes
@@ -60,55 +61,55 @@ def run_benchmark(config):
 
     )
     # Determine which metrics to compute based on config
-    metric_config = config.metric.name
-    compute_c2st = metric_config in ["c2st", "c2st_ppc"]
-    compute_ppc = metric_config in ["ppc", "c2st_ppc"]
+    metrics_raw = config.metric
+
+    # NOrmalize metrics_raw to a list
+    if isinstance(metrics_raw, (list, ListConfig)):
+        metrics_items = list(metrics_raw)
+    elif metrics_raw is None:
+        metrics_items = []
+    else:
+        metrics_items = [metrics_raw]
+
+    metric_name = str(getattr(config.metric, "name", config.metric)).lower()
+    metrics = [metric_name]  # keep your existing for-loop over `metrics`
+    print(f"metrics resolved: {metrics}")
+
+
 
     # Evaluation: collect all metrics for all obs, save one metrics.csv
     all_metrics = []
     for obs_idx in range(num_observations):
-
-        x_o = observations[obs_idx]
-        metrics_dict = {"obs_idx": obs_idx, "task": task_name, "method": method}
-
-
-        if compute_c2st:
-            c2st_score = evaluate_inference(
+        for metric in metrics:
+            metric_name = metric
+            score = evaluate_inference(
                 task=task,
-                method_name=method,
-                metric_name="c2st",
-                num_simulations=num_simulations,
-                obs_offset=obs_idx,
+                method_name = method,
+                metric_name = metric_name,
+                num_simulations = num_simulations,
+                obs_offset = obs_idx,
             )
             all_metrics.append({
-                "metric": "c2st",
-                "value": c2st_score,
+                "metric": metric_name,
+                "value": score,
                 "task": task_name,
                 "method": method,
                 "num_simulations": num_simulations,
                 "observation_idx": obs_idx,
             })
 
-        if compute_ppc:
-            ppc_score = evaluate_inference(
-                task=task,
-                method_name=method,
-                metric_name="ppc",
-                num_simulations=num_simulations,
-                obs_offset=obs_idx,
-            )
-            all_metrics.append({
-                "metric": "ppc",
-                "value": ppc_score,
-                "task": task_name,
-                "method": method,
-                "num_simulations": num_simulations,
-                "observation_idx": obs_idx
-            })
-
     # Save metrics.csv
     task_class_name = task.__class__.__name__
-    outdir = f"outputs/{task_class_name}_{method}/sims_{num_simulations}"
-    os.makedirs(outdir, exist_ok=True)
-    pd.DataFrame(all_metrics).to_csv(os.path.join(outdir, "metrics.csv"), index=False)
-    print(f"Saved metrics ➜ {os.path.join(outdir, 'metrics.csv')}")
+    outdir = Path(f"outputs/{task_class_name}_{method}/sims_{num_simulations}")
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    df = pd.DataFrame(all_metrics)
+
+    if df.empty:
+        print("No metrics to save.")
+    else:
+        # Save one .csv for each metric
+        for metric_name, subdf in df.groupby("metric"):
+            csv_path = outdir/f"metrics_{metric_name}.csv"
+            subdf.to_csv(csv_path, index=False)
+            print(f"Saved {metric_name} metrics ➜{csv_path}")

--- a/src/utils/consolidate_metrics.py
+++ b/src/utils/consolidate_metrics.py
@@ -62,7 +62,7 @@ def consolidate_metrics(input_dir: Path, output_file: Path) -> pd.DataFrame:
     """
     # 1) Merge CSV files
     # 1.1) Gather all 'metrics.csv' files from all simulation subfolders 'sim_*' at given input directory `input_dir`
-    csv_paths = gather_csv_files(data_sources="sims_*/metrics.csv", base_directory=input_dir)
+    csv_paths = gather_csv_files(data_sources="sims_*/metrics_all.csv", base_directory=input_dir)
     if not csv_paths:
         raise FileNotFoundError(f"No metrics.csv under {input_dir!r}")
 

--- a/src/utils/consolidate_metrics.py
+++ b/src/utils/consolidate_metrics.py
@@ -1,10 +1,10 @@
 """
-Consolidate all 'metrics.csv' files (of the same task and method) across simulations into a single DataFrame.
+Consolidate all 'metrics.csv' files (of the same task and method) across simulations and parameter sweeps into a single DataFrame.
 
 This will:
-1. Gather all 'metrics.csv' files from all simulation subfolders 'sim_*' at given input directory `input_dir`
+1. Recursively gather all 'metrics.csv' files under the given `input_dir`.
 2. Read and concatenate them into a single DataFrame.
-3. Validate and reorder columns.
+3. Dynamically detect all task parameter columns and ensure they are included in the output, sorted.
 4. Write the resulting DataFrame to 'output_file' as a .csv file, then return it.
 
 Usage:
@@ -22,14 +22,13 @@ from src.utils.csv_utils import gather_csv_files, read_csv_files, ensure_columns
 def parse_args():
     """Parse and return command-line arguments."""
     p = argparse.ArgumentParser(
-        description="Consolidate all 'metrics.csv' files (of the same task and method) across simulations into a "
-                    "single DataFrame."
+        description="Consolidate all 'metrics.csv' files (of the same task and method) across simulations and parameter sweeps into a single DataFrame."
     )
     p.add_argument(
         "--input_dir",
         type=Path,
         required=True,
-        help="Base directory containing sims_*/metrics.csv files to consolidate"
+        help="Base directory containing metrics.csv files to consolidate"
     )
     p.add_argument(
         "--output_file",
@@ -39,6 +38,9 @@ def parse_args():
     )
     return p.parse_args()
 
+def find_all_metrics_csvs(input_dir: Path):
+    # Recursively find all 'metrics.csv' files under input_dir
+    return list(input_dir.rglob("metrics.csv"))
 
 def consolidate_metrics(input_dir: Path, output_file: Path) -> pd.DataFrame:
     """
@@ -62,7 +64,7 @@ def consolidate_metrics(input_dir: Path, output_file: Path) -> pd.DataFrame:
     """
     # 1) Merge CSV files
     # 1.1) Gather all 'metrics.csv' files from all simulation subfolders 'sim_*' at given input directory `input_dir`
-    csv_paths = gather_csv_files(data_sources="sims_*/metrics_all.csv", base_directory=input_dir)
+    csv_paths = find_all_metrics_csvs(input_dir)
     if not csv_paths:
         raise FileNotFoundError(f"No metrics_all.csv under {input_dir!r}")
 
@@ -75,6 +77,11 @@ def consolidate_metrics(input_dir: Path, output_file: Path) -> pd.DataFrame:
     combined = pd.concat(frames, ignore_index=True)
 
 
+    # Determine all columns that appear in any frame
+    all_columns = set()
+    for df in frames:
+        all_columns.update(df.columns)
+
     # 2) Validate and reorder columns
     base_fieldnames = [
         "metric",
@@ -84,12 +91,33 @@ def consolidate_metrics(input_dir: Path, output_file: Path) -> pd.DataFrame:
         "num_simulations",
         "observation_idx",
     ]
-    combined = ensure_columns(combined, base_fieldnames)
+
+    # All other columns are assumed to be task parameters or extra metadata
+    task_param_columns = sorted([c for c in all_columns if c not in base_fieldnames])
 
 
-    # 3) Write out at given output directory 'output_file'
+    # Final column order: base + sorted task params
+    final_columns = base_fieldnames + task_param_columns
+
+    # Check for missing required columns FIRST
+    missing = [col for col in base_fieldnames if col not in combined.columns]
+    if missing:
+        raise ValueError(f"Missing required columns: {missing} in consolidated metrics.csv")
+
+    # Then: Ensure all columns are present (add missing ones as NaN, but after check above this is safe)
+    for col in final_columns:
+        if col not in combined.columns:
+            combined[col] = pd.NA
+
+    # Now check if present required columns have any missing values
+    na_cols = [col for col in base_fieldnames if combined[col].isnull().any()]
+    if na_cols:
+        raise ValueError(f"Required columns contain missing values: {na_cols}")
+
+    # Reorder columns
+    combined = combined[final_columns]
+
     combined.to_csv(output_file, index=False)
-
     return combined
 
 

--- a/src/utils/consolidate_metrics.py
+++ b/src/utils/consolidate_metrics.py
@@ -64,7 +64,7 @@ def consolidate_metrics(input_dir: Path, output_file: Path) -> pd.DataFrame:
     # 1.1) Gather all 'metrics.csv' files from all simulation subfolders 'sim_*' at given input directory `input_dir`
     csv_paths = gather_csv_files(data_sources="sims_*/metrics_all.csv", base_directory=input_dir)
     if not csv_paths:
-        raise FileNotFoundError(f"No metrics.csv under {input_dir!r}")
+        raise FileNotFoundError(f"No metrics_all.csv under {input_dir!r}")
 
     # 1.2) Read all .csv files
     frames = read_csv_files(csv_paths)

--- a/src/utils/postprocess_callback.py
+++ b/src/utils/postprocess_callback.py
@@ -7,11 +7,7 @@ from omegaconf import OmegaConf
 from src.utils.LinePlot import LinePlot
 from src.utils.consolidate_metrics import consolidate_metrics
 from src.tasks.misspecified_tasks import LikelihoodMisspecifiedTask
-
-# Task registry to hold all available task classes
-task_registry = {
-    "misspecified_likelihood": LikelihoodMisspecifiedTask,
-}
+from src.utils.benchmark_run import task_registry
 
 
 class PostProcessCallback(Callback):
@@ -35,7 +31,7 @@ class PostProcessCallback(Callback):
                 raise ValueError(f"Unknown task: {task_name}. Available: {list(task_registry.keys())}")
 
             # Initialize with arbitrary params to only infer the task class name
-            task_class_name = task_registry[task_name](1, 1, 1).__class__.__name__
+            task_class_name = task_registry[task_name].__name__
 
             method = str(cfg.inference.method).upper()
             num_simulations = int(cfg.inference.num_simulations)

--- a/src/utils/postprocess_callback.py
+++ b/src/utils/postprocess_callback.py
@@ -82,7 +82,7 @@ class PostProcessCallback(Callback):
         if len(unique_task_methods) == 1:
             # Only one unique task-method combination
             task = unique_task_methods.iloc[0]["task"]
-            method = unique_task_methods.iloc[0]["method"]
+            method = unique_task_methods.iloc[0]["method"].upper()
 
             save_directory = Path(f"outputs/{task}_{method}/plots")
         else:

--- a/src/utils/postprocess_callback.py
+++ b/src/utils/postprocess_callback.py
@@ -6,7 +6,6 @@ from omegaconf import OmegaConf
 
 from src.utils.LinePlot import LinePlot
 from src.utils.consolidate_metrics import consolidate_metrics
-from src.tasks.misspecified_tasks import LikelihoodMisspecifiedTask
 from src.utils.benchmark_run import task_registry
 
 

--- a/src/utils/postprocess_callback.py
+++ b/src/utils/postprocess_callback.py
@@ -62,7 +62,7 @@ class PostProcessCallback(Callback):
         # Consolidate all metrics.csv files into one DataFrame
         for _, row in unique_task_methods.iterrows():
             task = row["task"]
-            method = row["method"]
+            method = row["method"].upper()
             base_dir = Path("outputs") / f"{task}_{method}"
 
             for sim_dir in base_dir.glob("sims_*"):
@@ -91,7 +91,7 @@ class PostProcessCallback(Callback):
         # 3.3) Consolidate metrics.csv files to metrics_all.csv files within their respective task_method folder
         for _, row in unique_task_methods.iterrows():
             task = row["task"]
-            method = row["method"]
+            method = row["method"].upper()
             input_dir = Path("outputs") / f"{task}_{method}"
             output_file = input_dir / "metrics_all.csv"
 

--- a/src/utils/postprocess_callback.py
+++ b/src/utils/postprocess_callback.py
@@ -93,7 +93,7 @@ class PostProcessCallback(Callback):
         for _, row in unique_task_methods.iterrows():
             task = row["task"]
             method = row["method"]
-            input_dir = Path("outputs") / f"{task}_{method}"    # TODO !! changed task to concrete
+            input_dir = Path("outputs") / f"{task}_{method}"
             output_file = input_dir / "metrics_all.csv"
 
             consolidate_metrics(input_dir=input_dir, output_file=output_file)

--- a/tests/test_consolidate_metrics.py
+++ b/tests/test_consolidate_metrics.py
@@ -60,7 +60,7 @@ def test_consolidate_multiple_results(tmp_path):
 def test_consolidate_no_files(tmp_path):
     # Create an empty directory
     empty = tmp_path
-    output_file = tmp_path / "metrics_all.csv"
+    output_file = tmp_path / "metrics.csv"
 
     # Assert that a FileNotFoundError is raised when no metrics.csv files exist
     with pytest.raises(FileNotFoundError) as exc:

--- a/tests/test_consolidate_metrics.py
+++ b/tests/test_consolidate_metrics.py
@@ -60,12 +60,12 @@ def test_consolidate_multiple_results(tmp_path):
 def test_consolidate_no_files(tmp_path):
     # Create an empty directory
     empty = tmp_path
-    output_file = tmp_path / "metrics.csv"
+    output_file = tmp_path / "metrics_all.csv"
 
     # Assert that a FileNotFoundError is raised when no metrics.csv files exist
     with pytest.raises(FileNotFoundError) as exc:
         consolidate_metrics(input_dir=empty, output_file=output_file)
-    assert "No metrics.csv under" in str(exc.value)
+    assert "No metrics_all.csv under" in str(exc.value)
 
 
 def test_consolidate_unreadable_files(tmp_path):

--- a/tests/test_run_benchmark.py
+++ b/tests/test_run_benchmark.py
@@ -84,6 +84,8 @@ def test_postprocess_multirun_consolidation(tmp_path, monkeypatch):
     # Deactivate plotting to avoid Warnings during tests
     monkeypatch.setattr(LinePlot, "run", lambda self, *args, **kwargs: None)
 
+    # TEMPORARY: Re-Assert CWD, to check if the cwd is changed internally
+    monkeypatch.chdir(tmp_path)
 
     # Run PostProcessCallback
     PostProcessCallback().on_multirun_end(top_level_cfg)

--- a/tests/test_run_benchmark.py
+++ b/tests/test_run_benchmark.py
@@ -1,10 +1,14 @@
 import pandas as pd
 from omegaconf import OmegaConf
+from src.utils.postprocess_callback import PostProcessCallback, LinePlot
+
 
 from src.utils.benchmark_run import run_benchmark, task_registry
 from tests.test_evaluate import DummyTask
 
-def test_cfg():
+task_registry["test_task"] = DummyTask
+
+def cfg():
     return OmegaConf.create({
         "task": {"name": "test_task"},
         "inference": {
@@ -22,21 +26,88 @@ def test_run_creates_expected_outputs(tmp_path, monkeypatch):
 
     task_registry["test_task"] = DummyTask
 
-    run_benchmark(test_cfg())
+    run_benchmark(cfg())
 
     base = tmp_path / "outputs/DummyTask_NPE/sims_10"
     assert base.exists(), "Output directory was not created"
 
-    metrics_file = base / "metrics.csv"
-    assert metrics_file.exists(), "metrics.csv was not created"
+    single_metrics_file = base / "metrics_c2st.csv"
+    assert single_metrics_file.exists(), "metrics_c2st.csv was not created"
 
-def test_no_duplicates(tmp_path, monkeypatch):
+def multirun_cfg(metric_name: str):
+    return OmegaConf.create({
+        "task": {"name": "test_task"},
+        "inference": {
+            "method": "NPE",
+            "num_simulations": 10,
+            "num_observations": 2,
+            "num_posterior_samples": 5,
+        },
+        "metric": {"name": metric_name},
+        "random_seed": 42
+    })
+
+
+def test_postprocess_multirun_consolidation(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     task_registry["test_task"] = DummyTask
 
-    run_benchmark(test_cfg())
+    # Simulate two runs with two different metrics (as hydra sweeps would do)
+    for metric in ["ppc", "c2st"]:
+        cfg = multirun_cfg(metric)
+        run_benchmark(cfg)
 
-    metrics_file = tmp_path / "outputs/DummyTask_NPE/sims_10/metrics.csv"
+    # Set up Fake Hydra multirun path structure
+    sweep_dir = tmp_path / "multirun"
+    (sweep_dir / "0" / ".hydra").mkdir(parents=True, exist_ok=True)
+    (sweep_dir / "1" / ".hydra").mkdir(parents=True, exist_ok=True)
+
+    # Set up .hydra/config.yaml
+    job_cfg = {"task": {"name": "test_task"}, 
+               "inference": {"method": "NPE", "num_simulations": 10}}
+    
+    (sweep_dir / "0" / ".hydra" / "config.yaml").write_text(OmegaConf.to_yaml(OmegaConf.create(job_cfg)))
+    (sweep_dir / "1" / ".hydra" / "config.yaml").write_text(OmegaConf.to_yaml(OmegaConf.create(job_cfg)))
+
+
+    # Set up Top Level Config for PostProcessCallback
+    top_level_cfg = OmegaConf.create({
+        "hydra": {
+            "sweep": {
+                "dir": str(sweep_dir)
+            }
+        },
+        "task": {"name": "test_task"}
+    })
+
+    # Deactivate plotting to avoid Warnings during tests
+    monkeypatch.setattr(LinePlot, "run", lambda self, *args, **kwargs: None)
+
+
+    # Run PostProcessCallback
+    PostProcessCallback().on_multirun_end(top_level_cfg)
+
+    # Check consolidated files
+    # Check first consolidation step: per metric files for each simulation
+    base = tmp_path / "outputs/DummyTask_NPE"
+    simulations_path = base / "sims_10"
+
+    assert (simulations_path / "metrics_ppc.csv").exists(), "metrics_ppc.csv was not created"
+    assert (simulations_path / "metrics_c2st.csv").exists(), "metrics_c2st.csv was not created"
+
+    assert (simulations_path / "metrics.csv").exists(), "metrics.csv was not created -> Consolidation of metric-specific files failed"
+    
+
+    # Check second consolidation step: consolidated file across simulations
+    assert (base / "metrics_all.csv").exists(), "metrics_all.csv was not created -> Consolidation across simulations failed"
+
+
+    # Check contents of one of the metric files 
+    metrics_file = tmp_path / "outputs/DummyTask_NPE/sims_10/metrics_c2st.csv"
     df = pd.read_csv(metrics_file)
     assert len(df) == 2, "Expected two rows for two observations"
+
+
+
+    

--- a/tests/test_run_benchmark.py
+++ b/tests/test_run_benchmark.py
@@ -31,8 +31,8 @@ def test_run_creates_expected_outputs(tmp_path, monkeypatch):
     base = tmp_path / "outputs/DummyTask_NPE/sims_10"
     assert base.exists(), "Output directory was not created"
 
-    single_metrics_file = base / "metrics_c2st.csv"
-    assert single_metrics_file.exists(), "metrics_c2st.csv was not created"
+    single_metrics_file = base / "metrics_C2ST.csv"
+    assert single_metrics_file.exists(), "metrics_C2ST.csv was not created"
 
 def multirun_cfg(metric_name: str):
     return OmegaConf.create({
@@ -93,8 +93,8 @@ def test_postprocess_multirun_consolidation(tmp_path, monkeypatch):
     base = tmp_path / "outputs/DummyTask_NPE"
     simulations_path = base / "sims_10"
 
-    assert (simulations_path / "metrics_ppc.csv").exists(), "metrics_ppc.csv was not created"
-    assert (simulations_path / "metrics_c2st.csv").exists(), "metrics_c2st.csv was not created"
+    assert (simulations_path / "metrics_PPC.csv").exists(), "metrics_PPC.csv was not created"
+    assert (simulations_path / "metrics_C2ST.csv").exists(), "metrics_C2ST.csv was not created"
 
     assert (simulations_path / "metrics.csv").exists(), "metrics.csv was not created -> Consolidation of metric-specific files failed"
     

--- a/tests/test_run_benchmark.py
+++ b/tests/test_run_benchmark.py
@@ -106,7 +106,7 @@ def test_postprocess_multirun_consolidation(tmp_path, monkeypatch):
 
 
     # Check contents of one of the metric files 
-    metrics_file = tmp_path / "outputs/DummyTask_NPE/sims_10/metrics_c2st.csv"
+    metrics_file = simulations_path / "metrics_C2ST.csv"
     df = pd.read_csv(metrics_file)
     assert len(df) == 2, "Expected two rows for two observations"
 


### PR DESCRIPTION
## What does this PR do?

This PR enables to run multiple metrics in one Hydra Multirun.


The results are now: 
- A CSV file containing the result of one run with **one** metric `outputs\{task}_{method}\sims_{idx}\metrics_{metric}.csv`
- A consolidated CSV file containing the results of alle metrics `outputs\{task}_{method}\sims_{idx}\metrics.csv`
- A plot visualizing the consolidated CSV file.





## Does this close any issues?

Solves #89 



## Any relevant code examples, logs, or error messages?

I had to adjust the `postprocess_callback.py`so that we also consolidate the different metric_{metric}.csv files into one metrics.csv


## Anything else we should know?

Important to know is, that we need to use HYDRA Sweeper. I first tried to add a list in the default specification in `main,yaml`, which leeds to hydra ignoring the list and instead of running all given metrics only the last list entry is used. 

so we need to adjust the `main.yaml`in the following way: 
```yaml
defaults:
  - task: misspecified_likelihood
  - inference: npe
  - metric: ppc # Keep a default metric here
  - _self_

metrics_sweep: "c2st, ppc" # Add all metrics you want to use in the Multirun

random_seed: 86
postprocess: true

hydra:
  mode: MULTIRUN
  sweeper:
    params: 
      metric: ${metrics_sweep}  # Important to add another param that the sweeper has to sweep over
      inference.num_simulations: ${inference.num_simulations}
```


## Tests
I tested it manually and added/adjusted the unit tests as well, which passed locally on my computer. I honestly don't understand why the tests don't pass on the github server. If you have any ideas, please let me know!       

Right now it works pretty well (I suppose the problem is in the implementation of the tests and not the code itself as it works perfectly) , as we can see two different metric results in our Plot with sensible values. Here I used the example .yaml config i just gave in the last pararaph.
<img width="290" height="493" alt="{F5AE5225-8710-450D-A16F-0E2D99B521E3}" src="https://github.com/user-attachments/assets/a5a4ae20-09b8-46fc-8054-07171d0f09be" />

It also works if you accidentally only give one metrics in the sweeper. 
Here I used this configuration:
```yaml
defaults:
  - task: misspecified_likelihood
  - inference: npe
  - metric: ppc
  - _self_

metrics_sweep: "c2st"

random_seed: 86
postprocess: true

hydra:
  mode: MULTIRUN
  sweeper:
    params: 
      metric: ${metrics_sweep} 
      inference.num_simulations: ${inference.num_simulations}

  callbacks:
    postprocess:
      _target_: src.utils.postprocess_callback.PostProcessCallback
```
<img width="442" height="456" alt="{3BB1B001-2C41-4DDE-B02E-934D922B2FCF}" src="https://github.com/user-attachments/assets/fa75bfef-e49f-41ca-b1fc-2c84de158848" />


## ✅ Checklist

Put an `x` in the boxes that apply. If you're unsure about any of them, no worries—just ask!

- [ ] I have read and followed the [contribution guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [ ] I have added helpful comments to my code where needed
- [ ] I have added tests for new functionality
- [ ] (If applicable) I have reported how long new tests run and marked them with `pytest.mark.slow`

**For reviewers:**
- [ ] I have reviewed every file
- [ ] All comments have been addressed