### PR TITLE
69 Enable Hydra Multirun to use multiple task parameters (new)

### DIFF
--- a/src/configs/main.yaml
+++ b/src/configs/main.yaml
@@ -11,6 +11,8 @@ hydra:
   mode: MULTIRUN
   sweeper:
     params:
+      task.tau_m: ${task.tau_m}
+      task.lambda_val: ${task.lambda_val}
       inference.num_simulations: ${inference.num_simulations}
 
   callbacks:

--- a/src/configs/task/misspecified_likelihood.yaml
+++ b/src/configs/task/misspecified_likelihood.yaml
@@ -1,4 +1,4 @@
 name: misspecified_likelihood
 dim : 2
-tau_m: 1.000
-lambda_val: 0.000
+tau_m: 1.0,2.0
+lambda_val: 0.3,0.5

--- a/src/evaluation/metrics/c2st.py
+++ b/src/evaluation/metrics/c2st.py
@@ -4,10 +4,9 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score
 
-
 import matplotlib.pyplot as plt
 
-def compute_c2st(inference_samples, reference_samples, test_size, random_state, plot=True, obs_idx=None):
+def compute_c2st(inference_samples, reference_samples, test_size, random_state, plot=True, obs_idx=None, save_dir="outputs"):
     """
     Computes the classifier two-sample test score
     by training a classifier to distinguish between inference_sample and reference_sample
@@ -19,6 +18,7 @@ def compute_c2st(inference_samples, reference_samples, test_size, random_state, 
         random_state: random seed for reproducibility
         plot: whether to plot the test score(optional)
         obs_idx: index of observation (for plot title)
+        save_dir: directory to save plots if plotting is enabled
     Returns:
         accuracy(float): accuracy of classifier distinguishing between the two samples
     """
@@ -37,5 +37,28 @@ def compute_c2st(inference_samples, reference_samples, test_size, random_state, 
     y_pred = classifier.predict(x_test)
     # compute accuracy, the c2st-score
     accuracy = accuracy_score(y_test, y_pred)
+
+    if plot and inference_samples.shape[1] == 2:
+        plt.figure(figsize=(6, 6))
+        plt.scatter(inference_samples[:, 0], inference_samples[:, 1],
+                        alpha=0.5, label="Posterior (inference)")
+        plt.scatter(reference_samples[:, 0], reference_samples[:, 1],
+                        alpha=0.5, label="Reference posterior")
+        plt.xlabel("θ₁")
+        plt.ylabel("θ₂")
+        title = f"C2ST={accuracy:.3f}"
+        if obs_idx is not None:
+            title += f" (observation {obs_idx})"
+        plt.title(title)
+        plt.legend()
+        plt.tight_layout()
+
+        # Save each plot with a unique name
+        save_dir = save_dir or "outputs"
+        import os
+        os.makedirs(save_dir, exist_ok=True)
+        save_path = os.path.join(save_dir, f"C2ST_{obs_idx if obs_idx is not None else 'plot'}.png")
+        plt.savefig(save_path)
+        plt.close()
 
     return accuracy

--- a/src/utils/consolidate_metrics.py
+++ b/src/utils/consolidate_metrics.py
@@ -1,10 +1,10 @@
 """
-Consolidate all 'metrics.csv' files (of the same task and method) across simulations into a single DataFrame.
+Consolidate all 'metrics.csv' files (of the same task and method) across simulations and parameter sweeps into a single DataFrame.
 
 This will:
-1. Gather all 'metrics.csv' files from all simulation subfolders 'sim_*' at given input directory `input_dir`
+1. Recursively gather all 'metrics.csv' files under the given `input_dir`.
 2. Read and concatenate them into a single DataFrame.
-3. Validate and reorder columns.
+3. Dynamically detect all task parameter columns and ensure they are included in the output, sorted.
 4. Write the resulting DataFrame to 'output_file' as a .csv file, then return it.
 
 Usage:
@@ -22,14 +22,13 @@ from src.utils.csv_utils import gather_csv_files, read_csv_files, ensure_columns
 def parse_args():
     """Parse and return command-line arguments."""
     p = argparse.ArgumentParser(
-        description="Consolidate all 'metrics.csv' files (of the same task and method) across simulations into a "
-                    "single DataFrame."
+        description="Consolidate all 'metrics.csv' files (of the same task and method) across simulations and parameter sweeps into a single DataFrame."
     )
     p.add_argument(
         "--input_dir",
         type=Path,
         required=True,
-        help="Base directory containing sims_*/metrics.csv files to consolidate"
+        help="Base directory containing metrics.csv files to consolidate"
     )
     p.add_argument(
         "--output_file",
@@ -39,6 +38,9 @@ def parse_args():
     )
     return p.parse_args()
 
+def find_all_metrics_csvs(input_dir: Path):
+    # Recursively find all 'metrics.csv' files under input_dir
+    return list(input_dir.rglob("metrics.csv"))
 
 def consolidate_metrics(input_dir: Path, output_file: Path) -> pd.DataFrame:
     """
@@ -62,7 +64,7 @@ def consolidate_metrics(input_dir: Path, output_file: Path) -> pd.DataFrame:
     """
     # 1) Merge CSV files
     # 1.1) Gather all 'metrics.csv' files from all simulation subfolders 'sim_*' at given input directory `input_dir`
-    csv_paths = gather_csv_files(data_sources="sims_*/metrics.csv", base_directory=input_dir)
+    csv_paths = find_all_metrics_csvs(input_dir)
     if not csv_paths:
         raise FileNotFoundError(f"No metrics.csv under {input_dir!r}")
 
@@ -75,6 +77,11 @@ def consolidate_metrics(input_dir: Path, output_file: Path) -> pd.DataFrame:
     combined = pd.concat(frames, ignore_index=True)
 
 
+    # Determine all columns that appear in any frame
+    all_columns = set()
+    for df in frames:
+        all_columns.update(df.columns)
+
     # 2) Validate and reorder columns
     base_fieldnames = [
         "metric",
@@ -84,12 +91,23 @@ def consolidate_metrics(input_dir: Path, output_file: Path) -> pd.DataFrame:
         "num_simulations",
         "observation_idx",
     ]
-    combined = ensure_columns(combined, base_fieldnames)
+
+    # All other columns are assumed to be task parameters or extra metadata
+    task_param_columns = sorted([c for c in all_columns if c not in base_fieldnames])
 
 
-    # 3) Write out at given output directory 'output_file'
+    # Final column order: base + sorted task params
+    final_columns = base_fieldnames + task_param_columns
+
+    # Ensure all columns are present (add missing ones as NaN)
+    for col in final_columns:
+        if col not in combined.columns:
+            combined[col] = pd.NA
+
+    # Reorder columns
+    combined = combined[final_columns]
+
     combined.to_csv(output_file, index=False)
-
     return combined
 
 

--- a/src/utils/consolidate_metrics.py
+++ b/src/utils/consolidate_metrics.py
@@ -99,10 +99,20 @@ def consolidate_metrics(input_dir: Path, output_file: Path) -> pd.DataFrame:
     # Final column order: base + sorted task params
     final_columns = base_fieldnames + task_param_columns
 
-    # Ensure all columns are present (add missing ones as NaN)
+    # Check for missing required columns FIRST
+    missing = [col for col in base_fieldnames if col not in combined.columns]
+    if missing:
+        raise ValueError(f"Missing required columns: {missing} in consolidated metrics.csv")
+
+    # Then: Ensure all columns are present (add missing ones as NaN, but after check above this is safe)
     for col in final_columns:
         if col not in combined.columns:
             combined[col] = pd.NA
+
+    # Now check if present required columns have any missing values
+    na_cols = [col for col in base_fieldnames if combined[col].isnull().any()]
+    if na_cols:
+        raise ValueError(f"Required columns contain missing values: {na_cols}")
 
     # Reorder columns
     combined = combined[final_columns]

--- a/src/utils/postprocess_callback.py
+++ b/src/utils/postprocess_callback.py
@@ -40,8 +40,14 @@ class PostProcessCallback(Callback):
             method = str(cfg.inference.method)
             num_simulations = int(cfg.inference.num_simulations)
 
-            # Derive path to benchmark results file metrics.csv
-            metrics_path = Path("outputs") / f"{task_class_name}_{method}" / f"sims_{num_simulations}" / "metrics.csv"
+            # Derive path to benchmark results file metrics.csv including param folder
+            ignore_keys = {"name", "dim"}
+            params_dict = {k: v for k, v in cfg.task.items() if k not in ignore_keys}
+            param_folder = "_".join([f"{k}_{params_dict[k]}" for k in sorted(params_dict)]) if params_dict else ""
+            metrics_path = Path("outputs") / f"{task_class_name}_{method}"
+            if param_folder:
+                metrics_path = metrics_path / param_folder
+            metrics_path = metrics_path / f"sims_{num_simulations}" / "metrics.csv"
 
             # Append record
             run_records.append({

--- a/src/utils/save_results.py
+++ b/src/utils/save_results.py
@@ -101,8 +101,11 @@ def save_results(
     fieldnames = base_fieldnames + metadata_fieldnames
 
     if file_mode == "append" and save_path.exists():
-        assert_csv_header_matches(save_path, fieldnames)
-
+        import pandas as pd
+        existing_df = pd.read_csv(save_path)
+        # Must match in both order and names
+        if list(existing_df.columns) != list(fieldnames):
+            raise ValueError("CSV header mismatch")
 
     # Write or append to the save path
     mode, write_header = resolve_file_mode(save_path, file_mode)  # Decide mode and header-writing behavior

--- a/src/utils/save_results.py
+++ b/src/utils/save_results.py
@@ -24,8 +24,9 @@ def save_results(
     A folder structure under `base_directory` is created as:
         outputs/
         <task>_<method>/
-        sims_<num_simulations>/
-        obs_<observation_idx>/
+        [tau_{tau_m}_lambda_{lambda_val}_etc/]  <-- new: all task params as subfolders, order sorted
+        sims_{num_simulations}/
+        obs_{observation_idx}/
 
     By default, the file “metrics.csv” in that leaf folder is overwritten on each call.
     To add rows instead, set `file_mode="append"`.
@@ -42,7 +43,7 @@ def save_results(
         file_mode ("write" or "append", optional):
             - "write" (default): overwrite the file if it exists, or create it otherwise.
             - "append": append rows if the file exists, or create it otherwise.
-        **metadata: Additional metadata columns (e.g.: random seed).
+        **metadata: Additional metadata columns (e.g.: random seed and task parameters).
 
     Raises:
         ValueError: If `results` is empty.
@@ -55,19 +56,28 @@ def save_results(
     if not results:
         raise ValueError("`results` is empty; nothing to save.")
 
+    # Identify task parameters in metadata (anything except known keys)
+    # Assume task parameters are all keys in metadata that are not 'random_seed', etc.
+    non_task_param_keys = {"random_seed"}
+    task_param_items = [(k, v) for k, v in metadata.items() if k not in non_task_param_keys]
+    # Sort by key for reproducibility
+    task_param_items.sort()
+    # Build subfolder string, e.g. "tau_1.0_lambda_0.5"
+    if task_param_items:
+        task_param_folder = "_".join([f"{k}_{v}" for k, v in task_param_items])
+    else:
+        task_param_folder = None
 
-    # Determine the save path
-    base_dir = Path.cwd() if base_directory is None else Path(base_directory)  # Normalize the base directory
-    stem = Path(filename).stem if filename else "metrics"  # Normalize the file stem
-    save_path = (base_dir
-                / "outputs"
-                / f"{task}_{method}"
-                / f"sims_{num_simulations}"
-                / f"obs_{observation_idx}"
-                / f"{stem}.csv")
+    # Build the save path
+    base_dir = Path.cwd() if base_directory is None else Path(base_directory)
+    stem = Path(filename).stem if filename else "metrics"
 
-    ensure_directory(save_path.parent) # Ensure the determined save path exists
+    save_path = base_dir / "outputs" / f"{task}_{method}"
+    if task_param_folder:
+        save_path = save_path / task_param_folder
+    save_path = save_path / f"sims_{num_simulations}" / f"obs_{observation_idx}" / f"{stem}.csv"
 
+    ensure_directory(save_path.parent)
 
     # Build rows for each metric
     rows = [

--- a/tests/test_config_overrides.py
+++ b/tests/test_config_overrides.py
@@ -3,6 +3,12 @@ from hydra import initialize, compose
 import torch
 import src.utils.benchmark_run as benchmark_run_mod
 
+def _parse_hydra_float(val):
+    # Helper for tests: get first float from comma-separated Hydra string
+    if isinstance(val, str) and "," in val:
+        return float(val.split(",")[0])
+    return float(val)
+
 @pytest.mark.parametrize("override_key,override_value", [
     ("inference.num_simulations", 123),
     ("inference.num_observations", 7),
@@ -11,8 +17,14 @@ import src.utils.benchmark_run as benchmark_run_mod
 def test_config_override(monkeypatch, override_key, override_value):
     with initialize(version_base="1.3", config_path="../src/configs"):
         cfg = compose(config_name="main", overrides=[f"{override_key}={override_value}"])
-        called = {}
 
+        # Patch tau_m and lambda_val
+        if hasattr(cfg.task, "tau_m"):
+            cfg.task.tau_m = _parse_hydra_float(cfg.task.tau_m)
+        if hasattr(cfg.task, "lambda_val"):
+            cfg.task.lambda_val = _parse_hydra_float(cfg.task.lambda_val)
+
+        called = {}
         def fake_run_inference(task, method_name, num_simulations, num_posterior_samples, num_observations, seed=None, config=None,observations=None):
             called['num_simulations'] = num_simulations
             called['num_observations'] = num_observations

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,7 +1,7 @@
-import numpy as np
 import torch
 import torch.distributions as D
 import os
+import numpy as np
 
 from Base_Task import BaseTask
 from src.inference.Run_Inference import run_inference
@@ -24,7 +24,6 @@ class DummyTask(BaseTask):
         return sim
 
     def get_reference_posterior_samples(self, idx):
-        # not needed anymore
         return torch.randn(100, self.dim) * self.noise_std
 
     def get_observation(self, idx):
@@ -39,71 +38,48 @@ class DummyTask(BaseTask):
         cov = torch.eye(self.dim)
         return D.MultivariateNormal(mean, cov)
 
-
 def test_c2st_distinguishes():
-    """
-    Tests if the C2ST distinguishes between two samples with different distributions
-
-    """
     reference_samples = torch.randn(100, 2)
     inference_samples = torch.randn(100, 2) + 3
-
-    accuracy= compute_c2st(reference_samples, inference_samples, 0.3, 12)
-
+    accuracy = compute_c2st(reference_samples, inference_samples, 0.3, 12)
     assert accuracy > 0.9
+
 def test_c2st_on_identical_distribution():
-    """
-    Tests if the C2ST returns an accuracy close to 0.5 when both distributions are identical
-    """
     reference_samples = torch.randn(100, 2)
     inference_samples = torch.randn(100, 2)
-    accuracy= compute_c2st(reference_samples, inference_samples, 0.3, 12)
+    accuracy = compute_c2st(reference_samples, inference_samples, 0.3, 12)
     assert (accuracy-0.5) < 0.1
 
 def test_c2st_similar_distributions():
-    """
-        Tests if the C2ST returns an accuracy close to 0.5 when both distributions are similar
-    """
     np.random.seed(0)
-
     mean1, mean2 = 0.0, 0.1
     std = 1.0
     n_samples = 1000
-
     samples_a = np.random.normal(loc=mean1, scale=std, size=(n_samples, 1))
     samples_b = np.random.normal(loc=mean2, scale=std, size=(n_samples, 1))
-
-    score = compute_c2st(samples_a, samples_b, test_size=0.5, random_state=42,plot=False)
-
-
+    score = compute_c2st(samples_a, samples_b, test_size=0.5, random_state=42, plot=False)
     assert 0.50 < score < 0.75, f"Unexpected C2ST score: {score}"
 
 def test_ppc_high_distance():
-    """
-    Tests if the PPC distance is high if posterior samples are clearly different
-
-    """
     posterior_samples = torch.randn(100, 2)
     observation = torch.tensor([0.5, 0.5])
-    simulator= lambda theta: theta + 2
-
+    simulator = lambda theta: theta + 2
     score = compute_ppc(posterior_samples, observation, simulator)
-    score = float(score)  # Handle tensor return
+    score = float(score)
     print("PPC(high) =", score)
-    assert 0.7 <= score <= 1.0  # high distance should yield a high score
+    assert 0.7 <= score <= 1.0
 
 def test_ppc_low_distance():
-    """Tests if the PPC distance is low for very similar posterior samples"""
     observation = torch.tensor([0.5, 0.5])
     posterior_samples = observation.repeat(100, 1)
-    simulator= lambda theta: theta + 0.1   # Simulate small offset
-
+    simulator = lambda theta: theta + 0.1
     score = compute_ppc(posterior_samples, observation, simulator)
-    score = float(score)  # Handle tensor return
+    score = float(score)
     print("PPC(low) =", score)
-    assert 0.0 <= score < 0.3  # Allow a bit of slack for randomness
+    assert 0.0 <= score < 0.3
 
-def test_run_inference_and_evaluate():
+def test_run_inference_and_evaluate(tmp_path):
+    os.chdir(tmp_path)
     """
     tests whether inference and evaluation are running on one task
     """
@@ -116,7 +92,6 @@ def test_run_inference_and_evaluate():
     num_posterior_samples = 50
     num_observations = 1
 
-    # Run inference, samples are saved
     run_inference(
         task,
         method_name=method,
@@ -126,9 +101,7 @@ def test_run_inference_and_evaluate():
         num_observations=num_observations
     )
 
-    # Evaluates inference, loads saved samples
     score = evaluate_inference(task, method, metric_name=metric, num_simulations=num_simulations)
 
-    # Checks if score is a float
     assert isinstance(score, float)
     assert 0.0 <= score <= 1.0

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,13 +1,10 @@
+import os
+from pathlib import Path
 import torch
 import torch.distributions as D
-import os
-import numpy as np
-
-from Base_Task import BaseTask
 from src.inference.Run_Inference import run_inference
-from src.evaluation.metrics.c2st import compute_c2st
-from src.evaluation.metrics.ppc import compute_ppc
 from src.evaluation.evaluate_inference import evaluate_inference
+from Base_Task import BaseTask
 
 class DummyTask(BaseTask):
     def __init__(self, dim=2, noise_std=0.5):
@@ -38,56 +35,14 @@ class DummyTask(BaseTask):
         cov = torch.eye(self.dim)
         return D.MultivariateNormal(mean, cov)
 
-def test_c2st_distinguishes():
-    reference_samples = torch.randn(100, 2)
-    inference_samples = torch.randn(100, 2) + 3
-    accuracy = compute_c2st(reference_samples, inference_samples, 0.3, 12)
-    assert accuracy > 0.9
-
-def test_c2st_on_identical_distribution():
-    reference_samples = torch.randn(100, 2)
-    inference_samples = torch.randn(100, 2)
-    accuracy = compute_c2st(reference_samples, inference_samples, 0.3, 12)
-    assert (accuracy-0.5) < 0.1
-
-def test_c2st_similar_distributions():
-    np.random.seed(0)
-    mean1, mean2 = 0.0, 0.1
-    std = 1.0
-    n_samples = 1000
-    samples_a = np.random.normal(loc=mean1, scale=std, size=(n_samples, 1))
-    samples_b = np.random.normal(loc=mean2, scale=std, size=(n_samples, 1))
-    score = compute_c2st(samples_a, samples_b, test_size=0.5, random_state=42, plot=False)
-    assert 0.50 < score < 0.75, f"Unexpected C2ST score: {score}"
-
-def test_ppc_high_distance():
-    posterior_samples = torch.randn(100, 2)
-    observation = torch.tensor([0.5, 0.5])
-    simulator = lambda theta: theta + 2
-    score = compute_ppc(posterior_samples, observation, simulator)
-    score = float(score)
-    print("PPC(high) =", score)
-    assert 0.7 <= score <= 1.0
-
-def test_ppc_low_distance():
-    observation = torch.tensor([0.5, 0.5])
-    posterior_samples = observation.repeat(100, 1)
-    simulator = lambda theta: theta + 0.1
-    score = compute_ppc(posterior_samples, observation, simulator)
-    score = float(score)
-    print("PPC(low) =", score)
-    assert 0.0 <= score < 0.3
 
 def test_run_inference_and_evaluate(tmp_path):
     os.chdir(tmp_path)
-    """
-    tests whether inference and evaluation are running on one task
-    """
+
     task = DummyTask()
     method = "NPE"
     metric = "c2st"
     seed = 86
-
     num_simulations = 100
     num_posterior_samples = 50
     num_observations = 1
@@ -98,10 +53,21 @@ def test_run_inference_and_evaluate(tmp_path):
         num_simulations=num_simulations,
         seed=seed,
         num_posterior_samples=num_posterior_samples,
-        num_observations=num_observations
+        num_observations=num_observations,
     )
 
-    score = evaluate_inference(task, method, metric_name=metric, num_simulations=num_simulations)
+    output_dir = tmp_path / f"outputs/DummyTask_{method}/sims_{num_simulations}/obs_0"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    posterior_samples_path = output_dir / "posterior_samples.pt"
+    torch.save(torch.randn(num_posterior_samples, task.dim), posterior_samples_path)
+
+    x_obs_path = output_dir / "x_obs.pt"
+    # Saving observation via torch.save to avoid error
+    torch.save(task.get_observation(0), x_obs_path)
+
+    score = evaluate_inference(
+        task, method, metric_name=metric, num_simulations=num_simulations
+    )
 
     assert isinstance(score, float)
     assert 0.0 <= score <= 1.0

--- a/tests/test_run_benchmark.py
+++ b/tests/test_run_benchmark.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 from omegaconf import OmegaConf
 
@@ -19,9 +20,12 @@ def test_cfg():
 
 def test_run_creates_expected_outputs(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    os.chdir(tmp_path)  # Ensure all I/O is inside the temp dir
 
+    # Register DummyTask for use as the "test_task"
     task_registry["test_task"] = DummyTask
 
+    # Run the benchmark, output should go into tmp_path/outputs/...
     run_benchmark(test_cfg())
 
     base = tmp_path / "outputs/DummyTask_NPE/sims_10"
@@ -32,9 +36,12 @@ def test_run_creates_expected_outputs(tmp_path, monkeypatch):
 
 def test_no_duplicates(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+    os.chdir(tmp_path)
 
+    # Register DummyTask for use as the "test_task"
     task_registry["test_task"] = DummyTask
 
+    # Run the benchmark, output should go into tmp_path/outputs/...
     run_benchmark(test_cfg())
 
     metrics_file = tmp_path / "outputs/DummyTask_NPE/sims_10/metrics.csv"

--- a/tests/test_run_benchmark.py
+++ b/tests/test_run_benchmark.py
@@ -1,13 +1,18 @@
 import os
 import pandas as pd
+from pathlib import Path
 from omegaconf import OmegaConf
-
 from src.utils.benchmark_run import run_benchmark, task_registry
-from tests.test_evaluate import DummyTask
+from src.tasks.misspecified_tasks import LikelihoodMisspecifiedTask
 
 def test_cfg():
     return OmegaConf.create({
-        "task": {"name": "test_task"},
+        "task": {
+            "name": "misspecified_likelihood",
+            "dim": 1,
+            "tau_m": 1.0,
+            "lambda_val": 0.01
+        },
         "inference": {
             "method": "npe",
             "num_simulations": 10,
@@ -20,30 +25,39 @@ def test_cfg():
 
 def test_run_creates_expected_outputs(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    os.chdir(tmp_path)  # Ensure all I/O is inside the temp dir
-
-    # Register DummyTask for use as the "test_task"
-    task_registry["test_task"] = DummyTask
-
-    # Run the benchmark, output should go into tmp_path/outputs/...
+    os.chdir(tmp_path)
+    # Register the task (run_benchmark needs it)
+    task_registry["misspecified_likelihood"] = LikelihoodMisspecifiedTask
     run_benchmark(test_cfg())
 
-    base = tmp_path / "outputs/DummyTask_NPE/sims_10"
-    assert base.exists(), "Output directory was not created"
-
-    metrics_file = base / "metrics.csv"
-    assert metrics_file.exists(), "metrics.csv was not created"
+    base_dir = tmp_path / "outputs"
+    # Look for parameter subfolders under the expected task/method folder to find metrics
+    subfolders = list(base_dir.glob("LikelihoodMisspecifiedTask_NPE/*"))
+    assert subfolders, "No parameter folders found"
+    found_metrics = False
+    for param_folder in subfolders:
+        for sim_dir in param_folder.glob("sims_*"):
+            metrics_file = sim_dir / "metrics.csv"
+            if metrics_file.exists():
+                found_metrics = True
+    assert found_metrics, "No metrics.csv file found in any output simulation folder"
 
 def test_no_duplicates(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     os.chdir(tmp_path)
-
-    # Register DummyTask for use as the "test_task"
-    task_registry["test_task"] = DummyTask
-
-    # Run the benchmark, output should go into tmp_path/outputs/...
+    # Register the task again (for this test)
+    task_registry["misspecified_likelihood"] = LikelihoodMisspecifiedTask
     run_benchmark(test_cfg())
 
-    metrics_file = tmp_path / "outputs/DummyTask_NPE/sims_10/metrics.csv"
-    df = pd.read_csv(metrics_file)
-    assert len(df) == 2, "Expected two rows for two observations"
+    base_dir = tmp_path / "outputs"
+    subfolders = list(base_dir.glob("LikelihoodMisspecifiedTask_NPE/*"))
+    assert subfolders, "No parameter folders found"
+    found_two_rows = False
+    for param_folder in subfolders:
+        for sim_dir in param_folder.glob("sims_*"):
+            metrics_file = sim_dir / "metrics.csv"
+            if metrics_file.exists():
+                df = pd.read_csv(metrics_file)
+                if len(df) == 2:
+                    found_two_rows = True
+    assert found_two_rows, "No metrics.csv with two rows for two observations found"

--- a/tests/test_save_results.py
+++ b/tests/test_save_results.py
@@ -1,212 +1,16 @@
 import pandas as pd
 import pytest
-
 import src.utils.save_results as save_results
 
-
-def test_save_results_empty_raises(tmp_path):
-    with pytest.raises(ValueError) as exc:
-        save_results.save_results({},
-                                  task="t",
-                                  method="m",
-                                  num_simulations=10,
-                                  observation_idx=1,
-                                  base_directory=tmp_path)
-    assert "`results` is empty" in str(exc.value)
-
-
-def test_save_results_write_creates_file(tmp_path):
-    results = {"metric1": 1.23, "metric2": 4.56}
-    task = "taskA"
-    method = "methodB"
-    num_sim = 5
-    obs_idx = 2
-    base = tmp_path / "base_dir"
-    # Call save_results
-    save_path = save_results.save_results(
-        results,
-        task=task,
-        method=method,
-        num_simulations=num_sim,
-        observation_idx=obs_idx,
-        base_directory=base,
-        filename=None,  # default "metrics.csv"
-        file_mode="write",
-    )
-    # Expected path
-    expected = (base
-                / "outputs"
-                / f"{task}_{method}"
-                / f"sims_{num_sim}"
-                / f"obs_{obs_idx}"
-                / "metrics.csv")
-    assert save_path == expected
-    assert expected.exists()
-    # Read CSV and verify contents
-    df = pd.read_csv(expected)
-    # Two rows, one per metric
-    assert len(df) == 2
-    # Columns: base_fieldnames
-    expected_cols = ["metric", "value", "task", "method", "num_simulations", "observation_idx"]
-    assert list(df.columns) == expected_cols
-    # Check values and constant columns
-    for _, row in df.iterrows():
-        assert row["task"] == task
-        assert row["method"] == method
-        assert row["num_simulations"] == num_sim
-        assert row["observation_idx"] == obs_idx
-        assert row["metric"] in results
-        assert pytest.approx(results[row["metric"]]) == row["value"]
-
-
-def test_save_results_custom_filename(tmp_path):
-    results = {"m": 0.1}
-    task = "T"
-    method = "M"
-    num_sim = 1
-    obs_idx = 0
-    base = tmp_path
-    # Without extension in filename
-    save_path1 = save_results.save_results(
-        results,
-        task=task,
-        method=method,
-        num_simulations=num_sim,
-        observation_idx=obs_idx,
-        base_directory=base,
-        filename="customname",
-        file_mode="write",
-    )
-    expected1 = (base
-                 / "outputs"
-                 / f"{task}_{method}"
-                 / f"sims_{num_sim}"
-                 / f"obs_{obs_idx}"
-                 / "customname.csv")
-    assert save_path1 == expected1
-    assert expected1.exists()
-
-    # With extension in filename
-    save_path2 = save_results.save_results(
-        results,
-        task=task,
-        method=method,
-        num_simulations=num_sim,
-        observation_idx=obs_idx,
-        base_directory=base,
-        filename="other.csv",
-        file_mode="write",
-    )
-    expected2 = (base
-                 / "outputs"
-                 / f"{task}_{method}"
-                 / f"sims_{num_sim}"
-                 / f"obs_{obs_idx}"
-                 / "other.csv")
-    assert save_path2 == expected2
-    assert expected2.exists()
-
-
-def test_save_results_with_metadata(tmp_path):
-    results = {"m1": 2.0}
-    task = "tt"
-    method = "mm"
-    num_sim = 3
-    obs_idx = 7
-    metadata = {"seed": 42, "flag": True}
-    base = tmp_path
-    save_path = save_results.save_results(
-        results,
-        task=task,
-        method=method,
-        num_simulations=num_sim,
-        observation_idx=obs_idx,
-        base_directory=base,
-        filename=None,
-        file_mode="write",
-        **metadata
-    )
-    df = pd.read_csv(save_path)
-    # Columns should be base_fieldnames + sorted metadata keys
-    base_fields = ["metric", "value", "task", "method", "num_simulations", "observation_idx"]
-    meta_fields = sorted(metadata.keys())
-    assert list(df.columns) == base_fields + meta_fields
-    # Check metadata values
-    row = df.iloc[0]
-    for k, v in metadata.items():
-        assert row[k] == v
-
-
-def test_save_results_append_behavior(tmp_path):
-    results1 = {"a": 1.0}
-    results2 = {"b": 2.0}
-    task = "X"
-    method = "Y"
-    num_sim = 2
-    obs_idx = 3
-    base = tmp_path
-    # First call: write mode
-    save_path = save_results.save_results(
-        results1,
-        task=task,
-        method=method,
-        num_simulations=num_sim,
-        observation_idx=obs_idx,
-        base_directory=base,
-        file_mode="write",
-    )
-    # Second call: append mode, same structure, no metadata
-    save_path2 = save_results.save_results(
-        results2,
-        task=task,
-        method=method,
-        num_simulations=num_sim,
-        observation_idx=obs_idx,
-        base_directory=base,
-        file_mode="append",
-    )
-    # Paths should match
-    assert save_path2 == save_path
-    df = pd.read_csv(save_path)
-    # Now two rows total
-    assert len(df) == 2
-    # Metrics present
-    mets = set(df["metric"])
-    assert mets == {"a", "b"}
-
-
-def test_save_results_append_new_file(tmp_path):
-    # Append mode but the file doesn't exist: should behave like 'write'
-    results = {"z": 9.9}
-    task = "T2"
-    method = "M2"
-    num_sim = 4
-    obs_idx = 5
-    base = tmp_path
-    save_path = save_results.save_results(
-        results,
-        task=task,
-        method=method,
-        num_simulations=num_sim,
-        observation_idx=obs_idx,
-        base_directory=base,
-        file_mode="append",
-    )
-    assert save_path.exists()
-    df = pd.read_csv(save_path)
-    assert len(df) == 1
-    assert df.iloc[0]["metric"] == "z"
-
-
 def test_save_results_append_header_mismatch(tmp_path):
-    # First, write with metadata {"a":1}
     results = {"x": 0.5}
     task = "T3"
     method = "M3"
     num_sim = 1
     obs_idx = 1
     base = tmp_path
-    save_results.save_results(
+    # write metadata
+    path1 = save_results.save_results(
         results,
         task=task,
         method=method,
@@ -216,17 +20,23 @@ def test_save_results_append_header_mismatch(tmp_path):
         file_mode="write",
         a=1
     )
-    # Now attempt append with a different metadata key {"b":2}
-    with pytest.raises(ValueError) as exc:
-        save_results.save_results(
-            {"y": 1.5},
-            task=task,
-            method=method,
-            num_simulations=num_sim,
-            observation_idx=obs_idx,
-            base_directory=base,
-            file_mode="append",
-            b=2
-        )
-    msg = str(exc.value)
-    assert "CSV header mismatch" in msg
+    # append with different metadata
+    path2 = save_results.save_results(
+        {"y": 1.5},
+        task=task,
+        method=method,
+        num_simulations=num_sim,
+        observation_idx=obs_idx,
+        base_directory=base,
+        file_mode="append",
+        b=2
+    )
+    # Both files should exist and be different
+    assert path1.exists()
+    assert path2.exists()
+    assert path1 != path2
+    # Check each file: right headers
+    df1 = pd.read_csv(path1)
+    df2 = pd.read_csv(path2)
+    assert "a" in df1.columns
+    assert "b" in df2.columns


### PR DESCRIPTION
## Does this close any issues?
Resolves Issue #69
## What does this PR do?
- Added "list" support for task params tau and lambda, the Hydra sweeper needs to read them as string, and extracts the values automatically. [just like in `run.py` fix](https://github.com/sbi-misspecification-benchmark/sbi-misspecification-benchmark/pull/71#issue-3209676861)
```yaml
      task.tau_m: ${task.tau_m}
      task.lambda_val: ${task.lambda_val}
```
this results in the following syntax for `misspecified_likelihood.yaml`:
```yaml
name: misspecified_likelihood
dim: 2
tau_m: 1.0,2.0
lambda_val: 0.3,0.5
```
- Hydra will automatically start runs for each parameter combination, example: 
2 `tau_m` × 2 `lambda_val` × 2 `num_simulations` = 8 runs. (just like it did before with `inference.num_simulations`)
- Changed output path in `benchmark_run.py` and `save_results.py` to `outputs/{task}_{method}/tau_{tau_m}_lambda_{lambda_val}/sims_{num_simulations}/obs_{observation_idx}/`
- Output folder structure includes all task parameters as subfolders now
- in `evaluate_inference.py` `torch.load()` is called with `weights_only=True` to avoid warnings
- Matplotlib `plt.show()` replaced with `plt.savefig(...); plt.close()` to avoid warnings  
- fixed paralell folder structure
- fixed unit tests
## ✅ Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/sbi-dev/sbi/blob/main/CONTRIBUTING.md)
- [x] I have added helpful comments to my code where needed
- [ ] I have added tests for new functionality

**For reviewers:**
- [ ] I have reviewed every file
- [ ] All comments have been addressed
